### PR TITLE
feat all rating endpoint and docs

### DIFF
--- a/apperror/error.go
+++ b/apperror/error.go
@@ -77,7 +77,8 @@ var (
 	InvalidProfileImageExtension  = &AppErrorType{http.StatusBadRequest, "invalid-profile-image-extensions"}
 
 	// rating errors
-	RatingNotFound = &AppErrorType{http.StatusNotFound, "rating-not-found"}
+	RatingNotFound  = &AppErrorType{http.StatusNotFound, "rating-not-found"}
+	InvalidRatingId = &AppErrorType{http.StatusBadRequest, "invalid-rating-id"}
 
 	InvalidAgreementId = &AppErrorType{http.StatusBadRequest, "invalid-agreement-id"}
 	AgreementNotFound  = &AppErrorType{http.StatusNotFound, "agreement-not-found"}

--- a/apperror/error.go
+++ b/apperror/error.go
@@ -76,6 +76,9 @@ var (
 	ServiceUnavailable            = &AppErrorType{http.StatusServiceUnavailable, "service-unavailable"}
 	InvalidProfileImageExtension  = &AppErrorType{http.StatusBadRequest, "invalid-profile-image-extensions"}
 
+	// rating errors
+	RatingNotFound = &AppErrorType{http.StatusNotFound, "rating-not-found"}
+
 	InvalidAgreementId = &AppErrorType{http.StatusBadRequest, "invalid-agreement-id"}
 	AgreementNotFound  = &AppErrorType{http.StatusNotFound, "agreement-not-found"}
 	DuplicateAgreement = &AppErrorType{http.StatusBadRequest, "duplicate-agreement"}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -185,6 +185,7 @@ func main() {
 	apiv1.Get("/chats/:recvUserId", mw.AuthMiddlewareWrapper(chatHandler.GetMessagesInChat))
 
 	apiv1.Post("/ratings", mw.AuthMiddlewareWrapper(ratingsHandler.CreateRating))
+	apiv1.Get("/ratings/:propertyId", mw.AuthMiddlewareWrapper(ratingsHandler.GetRatingByPropertyId))
 
 	ws := app.Group("/ws")
 	ws.Get("/chats", websocket.New(chatHandler.OpenConnection))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -187,6 +187,7 @@ func main() {
 	apiv1.Post("/ratings", mw.AuthMiddlewareWrapper(ratingsHandler.CreateRating))
 	apiv1.Get("/ratings/:propertyId", mw.AuthMiddlewareWrapper(ratingsHandler.GetRatingByPropertyId))
 	apiv1.Get("/ratings", mw.AuthMiddlewareWrapper(ratingsHandler.GetAllRatings))
+	apiv1.Get("/ratings/sorted/:propertyId", mw.AuthMiddlewareWrapper(ratingsHandler.GetRatingByPropertyIdSortedByRating))
 
 	ws := app.Group("/ws")
 	ws.Get("/chats", websocket.New(chatHandler.OpenConnection))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -186,6 +186,7 @@ func main() {
 
 	apiv1.Post("/ratings", mw.AuthMiddlewareWrapper(ratingsHandler.CreateRating))
 	apiv1.Get("/ratings/:propertyId", mw.AuthMiddlewareWrapper(ratingsHandler.GetRatingByPropertyId))
+	apiv1.Get("/ratings", mw.AuthMiddlewareWrapper(ratingsHandler.GetAllRatings))
 
 	ws := app.Group("/ws")
 	ws.Get("/chats", websocket.New(chatHandler.OpenConnection))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -190,6 +190,7 @@ func main() {
 	apiv1.Get("/ratings/sorted/:propertyId", mw.AuthMiddlewareWrapper(ratingsHandler.GetRatingByPropertyIdSortedByRating))
 	apiv1.Get("/ratings/newest/:propertyId", mw.AuthMiddlewareWrapper(ratingsHandler.GetRatingByPropertyIdSortedByNewest))
 	apiv1.Patch("/ratings/:ratingId", mw.AuthMiddlewareWrapper(ratingsHandler.UpdateRatingStatus))
+	apiv1.Delete("/ratings/:ratingId", mw.AuthMiddlewareWrapper(ratingsHandler.DeleteRating))
 
 	ws := app.Group("/ws")
 	ws.Get("/chats", websocket.New(chatHandler.OpenConnection))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -188,6 +188,7 @@ func main() {
 	apiv1.Get("/ratings/:propertyId", mw.AuthMiddlewareWrapper(ratingsHandler.GetRatingByPropertyId))
 	apiv1.Get("/ratings", mw.AuthMiddlewareWrapper(ratingsHandler.GetAllRatings))
 	apiv1.Get("/ratings/sorted/:propertyId", mw.AuthMiddlewareWrapper(ratingsHandler.GetRatingByPropertyIdSortedByRating))
+	apiv1.Get("/ratings/newest/:propertyId", mw.AuthMiddlewareWrapper(ratingsHandler.GetRatingByPropertyIdSortedByNewest))
 
 	ws := app.Group("/ws")
 	ws.Get("/chats", websocket.New(chatHandler.OpenConnection))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -189,6 +189,7 @@ func main() {
 	apiv1.Get("/ratings", mw.AuthMiddlewareWrapper(ratingsHandler.GetAllRatings))
 	apiv1.Get("/ratings/sorted/:propertyId", mw.AuthMiddlewareWrapper(ratingsHandler.GetRatingByPropertyIdSortedByRating))
 	apiv1.Get("/ratings/newest/:propertyId", mw.AuthMiddlewareWrapper(ratingsHandler.GetRatingByPropertyIdSortedByNewest))
+	apiv1.Patch("/ratings/:ratingId", mw.AuthMiddlewareWrapper(ratingsHandler.UpdateRatingStatus))
 
 	ws := app.Group("/ws")
 	ws.Get("/chats", websocket.New(chatHandler.OpenConnection))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/brain-flowing-company/pprp-backend/internal/core/greetings"
 	"github.com/brain-flowing-company/pprp-backend/internal/core/payments"
 	"github.com/brain-flowing-company/pprp-backend/internal/core/properties"
+	"github.com/brain-flowing-company/pprp-backend/internal/core/ratings"
 	"github.com/brain-flowing-company/pprp-backend/internal/core/users"
 	"github.com/brain-flowing-company/pprp-backend/internal/middleware"
 	"github.com/brain-flowing-company/pprp-backend/storage"
@@ -122,6 +123,10 @@ func main() {
 	paymentsService := payments.NewService(logger, paymentsRepository, cfg)
 	paymentsHandler := payments.NewHandler(cfg, paymentsService)
 
+	ratingsRepository := ratings.NewRepository(db)
+	ratingsService := ratings.NewService(ratingsRepository, logger, cfg)
+	ratingsHandler := ratings.NewHandler(ratingsService)
+
 	mw := middleware.NewMiddleware(cfg)
 
 	apiv1 := app.Group("/api/v1", mw.SessionMiddleware)
@@ -178,6 +183,8 @@ func main() {
 
 	apiv1.Get("/chats", mw.AuthMiddlewareWrapper(chatHandler.GetAllChats))
 	apiv1.Get("/chats/:recvUserId", mw.AuthMiddlewareWrapper(chatHandler.GetMessagesInChat))
+
+	apiv1.Post("/ratings", mw.AuthMiddlewareWrapper(ratingsHandler.CreateRating))
 
 	ws := app.Group("/ws")
 	ws.Get("/chats", websocket.New(chatHandler.OpenConnection))

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1549,6 +1549,315 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/ratings": {
+            "get": {
+                "description": "Get all ratings",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ratings"
+                ],
+                "summary": "Get all ratings",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.RatingResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Create rating",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ratings"
+                ],
+                "summary": "Create rating",
+                "parameters": [
+                    {
+                        "description": " rating: Rating4_5 | Rating4 | Rating3_5 | Rating3",
+                        "name": "rating",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "review",
+                        "name": "review",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "property_id",
+                        "name": "property_id",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.RatingResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/ratings/:propertyId": {
+            "get": {
+                "description": "Get rating by property id",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ratings"
+                ],
+                "summary": "Get rating by property id",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "propertyId",
+                        "name": "propertyId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.RatingResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/ratings/:ratingId": {
+            "patch": {
+                "description": "Update rating status",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ratings"
+                ],
+                "summary": "Update rating status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ratingId",
+                        "name": "ratingId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "review",
+                        "name": "review",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "rating",
+                        "name": "rating",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.MessageResponses"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/ratings/newest/:propertyId": {
+            "get": {
+                "description": "Get rating by property id sorted by newest",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ratings"
+                ],
+                "summary": "Get rating by property id sorted by newest",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "propertyId",
+                        "name": "propertyId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.RatingResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/ratings/sorted/:propertyId": {
+            "get": {
+                "description": "Get rating by property id sorted by rating",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ratings"
+                ],
+                "summary": "Get rating by property id sorted by rating",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "propertyId",
+                        "name": "propertyId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.RatingResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/register": {
             "post": {
                 "description": "Create user with formData **\\***upload profile image in formData with field ` + "`" + `profile_image` + "`" + `. Available formats are .png / .jpg / .jpeg",
@@ -2333,6 +2642,35 @@ const docTemplate = `{
                 "HOUSE",
                 "SERVICED_APARTMENT",
                 "TOWNHOUSE"
+            ]
+        },
+        "enums.Rating": {
+            "type": "string",
+            "enum": [
+                "Rating0",
+                "Rating0_5",
+                "Rating1",
+                "Rating1_5",
+                "Rating2",
+                "Rating2_5",
+                "Rating3",
+                "Rating3_5",
+                "Rating4",
+                "Rating4_5",
+                "Rating5"
+            ],
+            "x-enum-varnames": [
+                "Rating0",
+                "Rating0_5",
+                "Rating1",
+                "Rating1_5",
+                "Rating2",
+                "Rating2_5",
+                "Rating3",
+                "Rating3_5",
+                "Rating4",
+                "Rating4_5",
+                "Rating5"
             ]
         },
         "enums.RegisteredTypes": {
@@ -3502,6 +3840,35 @@ const docTemplate = `{
                 "image_url": {
                     "type": "string",
                     "example": "https://image_url.com/abcd"
+                }
+            }
+        },
+        "models.RatingResponse": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "dweller_user_id": {
+                    "type": "string"
+                },
+                "first_name": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string"
+                },
+                "property_id": {
+                    "type": "string"
+                },
+                "rating": {
+                    "$ref": "#/definitions/enums.Rating"
+                },
+                "review": {
+                    "type": "string"
+                },
+                "review_id": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1597,12 +1597,12 @@ const docTemplate = `{
                 "summary": "Create rating",
                 "parameters": [
                     {
-                        "description": " rating: Rating4_5 | Rating4 | Rating3_5 | Rating3",
+                        "description": "rating",
                         "name": "rating",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "integer"
                         }
                     },
                     {
@@ -1777,7 +1777,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "integer"
                         }
                     }
                 ],
@@ -2687,35 +2687,6 @@ const docTemplate = `{
                 "HOUSE",
                 "SERVICED_APARTMENT",
                 "TOWNHOUSE"
-            ]
-        },
-        "enums.Rating": {
-            "type": "string",
-            "enum": [
-                "Rating0",
-                "Rating0_5",
-                "Rating1",
-                "Rating1_5",
-                "Rating2",
-                "Rating2_5",
-                "Rating3",
-                "Rating3_5",
-                "Rating4",
-                "Rating4_5",
-                "Rating5"
-            ],
-            "x-enum-varnames": [
-                "Rating0",
-                "Rating0_5",
-                "Rating1",
-                "Rating1_5",
-                "Rating2",
-                "Rating2_5",
-                "Rating3",
-                "Rating3_5",
-                "Rating4",
-                "Rating4_5",
-                "Rating5"
             ]
         },
         "enums.RegisteredTypes": {
@@ -3907,7 +3878,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "rating": {
-                    "$ref": "#/definitions/enums.Rating"
+                    "type": "integer"
                 },
                 "review": {
                     "type": "string"

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1700,6 +1700,51 @@ const docTemplate = `{
             }
         },
         "/api/v1/ratings/:ratingId": {
+            "delete": {
+                "description": "Delete rating",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ratings"
+                ],
+                "summary": "Delete rating",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ratingId",
+                        "name": "ratingId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.MessageResponses"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    }
+                }
+            },
             "patch": {
                 "description": "Update rating status",
                 "produces": [

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1591,12 +1591,12 @@
                 "summary": "Create rating",
                 "parameters": [
                     {
-                        "description": " rating: Rating4_5 | Rating4 | Rating3_5 | Rating3",
+                        "description": "rating",
                         "name": "rating",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "integer"
                         }
                     },
                     {
@@ -1771,7 +1771,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "integer"
                         }
                     }
                 ],
@@ -2681,35 +2681,6 @@
                 "HOUSE",
                 "SERVICED_APARTMENT",
                 "TOWNHOUSE"
-            ]
-        },
-        "enums.Rating": {
-            "type": "string",
-            "enum": [
-                "Rating0",
-                "Rating0_5",
-                "Rating1",
-                "Rating1_5",
-                "Rating2",
-                "Rating2_5",
-                "Rating3",
-                "Rating3_5",
-                "Rating4",
-                "Rating4_5",
-                "Rating5"
-            ],
-            "x-enum-varnames": [
-                "Rating0",
-                "Rating0_5",
-                "Rating1",
-                "Rating1_5",
-                "Rating2",
-                "Rating2_5",
-                "Rating3",
-                "Rating3_5",
-                "Rating4",
-                "Rating4_5",
-                "Rating5"
             ]
         },
         "enums.RegisteredTypes": {
@@ -3901,7 +3872,7 @@
                     "type": "string"
                 },
                 "rating": {
-                    "$ref": "#/definitions/enums.Rating"
+                    "type": "integer"
                 },
                 "review": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1694,6 +1694,51 @@
             }
         },
         "/api/v1/ratings/:ratingId": {
+            "delete": {
+                "description": "Delete rating",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ratings"
+                ],
+                "summary": "Delete rating",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ratingId",
+                        "name": "ratingId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.MessageResponses"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    }
+                }
+            },
             "patch": {
                 "description": "Update rating status",
                 "produces": [

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1543,6 +1543,315 @@
                 }
             }
         },
+        "/api/v1/ratings": {
+            "get": {
+                "description": "Get all ratings",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ratings"
+                ],
+                "summary": "Get all ratings",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.RatingResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Create rating",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ratings"
+                ],
+                "summary": "Create rating",
+                "parameters": [
+                    {
+                        "description": " rating: Rating4_5 | Rating4 | Rating3_5 | Rating3",
+                        "name": "rating",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "review",
+                        "name": "review",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "property_id",
+                        "name": "property_id",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.RatingResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/ratings/:propertyId": {
+            "get": {
+                "description": "Get rating by property id",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ratings"
+                ],
+                "summary": "Get rating by property id",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "propertyId",
+                        "name": "propertyId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.RatingResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/ratings/:ratingId": {
+            "patch": {
+                "description": "Update rating status",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ratings"
+                ],
+                "summary": "Update rating status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ratingId",
+                        "name": "ratingId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "review",
+                        "name": "review",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "rating",
+                        "name": "rating",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.MessageResponses"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/ratings/newest/:propertyId": {
+            "get": {
+                "description": "Get rating by property id sorted by newest",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ratings"
+                ],
+                "summary": "Get rating by property id sorted by newest",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "propertyId",
+                        "name": "propertyId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.RatingResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/ratings/sorted/:propertyId": {
+            "get": {
+                "description": "Get rating by property id sorted by rating",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ratings"
+                ],
+                "summary": "Get rating by property id sorted by rating",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "propertyId",
+                        "name": "propertyId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.RatingResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponses"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/register": {
             "post": {
                 "description": "Create user with formData **\\***upload profile image in formData with field `profile_image`. Available formats are .png / .jpg / .jpeg",
@@ -2327,6 +2636,35 @@
                 "HOUSE",
                 "SERVICED_APARTMENT",
                 "TOWNHOUSE"
+            ]
+        },
+        "enums.Rating": {
+            "type": "string",
+            "enum": [
+                "Rating0",
+                "Rating0_5",
+                "Rating1",
+                "Rating1_5",
+                "Rating2",
+                "Rating2_5",
+                "Rating3",
+                "Rating3_5",
+                "Rating4",
+                "Rating4_5",
+                "Rating5"
+            ],
+            "x-enum-varnames": [
+                "Rating0",
+                "Rating0_5",
+                "Rating1",
+                "Rating1_5",
+                "Rating2",
+                "Rating2_5",
+                "Rating3",
+                "Rating3_5",
+                "Rating4",
+                "Rating4_5",
+                "Rating5"
             ]
         },
         "enums.RegisteredTypes": {
@@ -3496,6 +3834,35 @@
                 "image_url": {
                     "type": "string",
                     "example": "https://image_url.com/abcd"
+                }
+            }
+        },
+        "models.RatingResponse": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "dweller_user_id": {
+                    "type": "string"
+                },
+                "first_name": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string"
+                },
+                "property_id": {
+                    "type": "string"
+                },
+                "rating": {
+                    "$ref": "#/definitions/enums.Rating"
+                },
+                "review": {
+                    "type": "string"
+                },
+                "review_id": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2210,6 +2210,36 @@ paths:
       tags:
       - ratings
   /api/v1/ratings/:ratingId:
+    delete:
+      description: Delete rating
+      parameters:
+      - description: ratingId
+        in: path
+        name: ratingId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.MessageResponses'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.ErrorResponses'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/models.ErrorResponses'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.ErrorResponses'
+      summary: Delete rating
+      tags:
+      - ratings
     patch:
       description: Update rating status
       parameters:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -126,6 +126,32 @@ definitions:
     - HOUSE
     - SERVICED_APARTMENT
     - TOWNHOUSE
+  enums.Rating:
+    enum:
+    - Rating0
+    - Rating0_5
+    - Rating1
+    - Rating1_5
+    - Rating2
+    - Rating2_5
+    - Rating3
+    - Rating3_5
+    - Rating4
+    - Rating4_5
+    - Rating5
+    type: string
+    x-enum-varnames:
+    - Rating0
+    - Rating0_5
+    - Rating1
+    - Rating1_5
+    - Rating2
+    - Rating2_5
+    - Rating3
+    - Rating3_5
+    - Rating4
+    - Rating4_5
+    - Rating5
   enums.RegisteredTypes:
     enum:
     - EMAIL
@@ -914,6 +940,25 @@ definitions:
         type: string
       image_url:
         example: https://image_url.com/abcd
+        type: string
+    type: object
+  models.RatingResponse:
+    properties:
+      created_at:
+        type: string
+      dweller_user_id:
+        type: string
+      first_name:
+        type: string
+      last_name:
+        type: string
+      property_id:
+        type: string
+      rating:
+        $ref: '#/definitions/enums.Rating'
+      review:
+        type: string
+      review_id:
         type: string
     type: object
   models.RentingProperties:
@@ -2065,6 +2110,210 @@ paths:
       summary: Add property to favorites *use cookies*
       tags:
       - property
+  /api/v1/ratings:
+    get:
+      description: Get all ratings
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.RatingResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.ErrorResponses'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/models.ErrorResponses'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.ErrorResponses'
+      summary: Get all ratings
+      tags:
+      - ratings
+    post:
+      description: Create rating
+      parameters:
+      - description: ' rating: Rating4_5 | Rating4 | Rating3_5 | Rating3'
+        in: body
+        name: rating
+        required: true
+        schema:
+          type: string
+      - description: review
+        in: body
+        name: review
+        required: true
+        schema:
+          type: string
+      - description: property_id
+        in: body
+        name: property_id
+        required: true
+        schema:
+          type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.RatingResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.ErrorResponses'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/models.ErrorResponses'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.ErrorResponses'
+      summary: Create rating
+      tags:
+      - ratings
+  /api/v1/ratings/:propertyId:
+    get:
+      description: Get rating by property id
+      parameters:
+      - description: propertyId
+        in: path
+        name: propertyId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.RatingResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.ErrorResponses'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/models.ErrorResponses'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.ErrorResponses'
+      summary: Get rating by property id
+      tags:
+      - ratings
+  /api/v1/ratings/:ratingId:
+    patch:
+      description: Update rating status
+      parameters:
+      - description: ratingId
+        in: path
+        name: ratingId
+        required: true
+        type: string
+      - description: review
+        in: body
+        name: review
+        required: true
+        schema:
+          type: string
+      - description: rating
+        in: body
+        name: rating
+        required: true
+        schema:
+          type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.MessageResponses'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.ErrorResponses'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/models.ErrorResponses'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.ErrorResponses'
+      summary: Update rating status
+      tags:
+      - ratings
+  /api/v1/ratings/newest/:propertyId:
+    get:
+      description: Get rating by property id sorted by newest
+      parameters:
+      - description: propertyId
+        in: path
+        name: propertyId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.RatingResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.ErrorResponses'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/models.ErrorResponses'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.ErrorResponses'
+      summary: Get rating by property id sorted by newest
+      tags:
+      - ratings
+  /api/v1/ratings/sorted/:propertyId:
+    get:
+      description: Get rating by property id sorted by rating
+      parameters:
+      - description: propertyId
+        in: path
+        name: propertyId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.RatingResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.ErrorResponses'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/models.ErrorResponses'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.ErrorResponses'
+      summary: Get rating by property id sorted by rating
+      tags:
+      - ratings
   /api/v1/register:
     post:
       description: Create user with formData **\***upload profile image in formData

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -126,32 +126,6 @@ definitions:
     - HOUSE
     - SERVICED_APARTMENT
     - TOWNHOUSE
-  enums.Rating:
-    enum:
-    - Rating0
-    - Rating0_5
-    - Rating1
-    - Rating1_5
-    - Rating2
-    - Rating2_5
-    - Rating3
-    - Rating3_5
-    - Rating4
-    - Rating4_5
-    - Rating5
-    type: string
-    x-enum-varnames:
-    - Rating0
-    - Rating0_5
-    - Rating1
-    - Rating1_5
-    - Rating2
-    - Rating2_5
-    - Rating3
-    - Rating3_5
-    - Rating4
-    - Rating4_5
-    - Rating5
   enums.RegisteredTypes:
     enum:
     - EMAIL
@@ -955,7 +929,7 @@ definitions:
       property_id:
         type: string
       rating:
-        $ref: '#/definitions/enums.Rating'
+        type: integer
       review:
         type: string
       review_id:
@@ -2138,12 +2112,12 @@ paths:
     post:
       description: Create rating
       parameters:
-      - description: ' rating: Rating4_5 | Rating4 | Rating3_5 | Rating3'
+      - description: rating
         in: body
         name: rating
         required: true
         schema:
-          type: string
+          type: integer
       - description: review
         in: body
         name: review
@@ -2259,7 +2233,7 @@ paths:
         name: rating
         required: true
         schema:
-          type: string
+          type: integer
       produces:
       - application/json
       responses:

--- a/internal/core/ratings/ratings.handler.go
+++ b/internal/core/ratings/ratings.handler.go
@@ -16,6 +16,7 @@ type Handler interface {
 	GetAllRatings(c *fiber.Ctx) error
 	GetRatingByPropertyIdSortedByRating(c *fiber.Ctx) error
 	GetRatingByPropertyIdSortedByNewest(c *fiber.Ctx) error
+	UpdateRatingStatus(c *fiber.Ctx) error
 }
 
 type handlerImpl struct {
@@ -104,4 +105,26 @@ func (h *handlerImpl) GetRatingByPropertyIdSortedByNewest(c *fiber.Ctx) error {
 		return utils.ResponseError(c, err)
 	}
 	return c.JSON(ratings)
+}
+
+func (h *handlerImpl) UpdateRatingStatus(c *fiber.Ctx) error {
+	updatingRating := models.UpdateRatingStatus{}
+	err := c.BodyParser(&updatingRating)
+	if err != nil {
+		return utils.ResponseError(c, apperror.New(apperror.BadRequest).Describe("Failed to parse body"))
+	}
+	ratingId := c.Params("ratingId")
+	ratingIdParsed, err := uuid.Parse(ratingId)
+	if err != nil {
+		return utils.ResponseError(c, apperror.New(apperror.BadRequest).Describe("Invalid rating ID"))
+	}
+	apperr := h.service.UpdateRatingStatus(&updatingRating, ratingIdParsed)
+	if apperr != nil {
+		return utils.ResponseError(c, apperr)
+	}
+	return c.JSON(fiber.Map{
+		"success": true,
+		"message": "Rating status updated successfully",
+	})
+
 }

--- a/internal/core/ratings/ratings.handler.go
+++ b/internal/core/ratings/ratings.handler.go
@@ -14,6 +14,7 @@ type Handler interface {
 	CreateRating(c *fiber.Ctx) error
 	GetRatingByPropertyId(c *fiber.Ctx) error
 	GetAllRatings(c *fiber.Ctx) error
+	GetRatingByPropertyIdSortedByRating(c *fiber.Ctx) error
 }
 
 type handlerImpl struct {
@@ -71,6 +72,20 @@ func (h *handlerImpl) GetRatingByPropertyId(c *fiber.Ctx) error {
 func (h *handlerImpl) GetAllRatings(c *fiber.Ctx) error {
 	var ratings []models.RatingResponse
 	if err := h.service.GetAllRatings(&ratings); err != nil {
+		return utils.ResponseError(c, err)
+	}
+	return c.JSON(ratings)
+}
+
+func (h *handlerImpl) GetRatingByPropertyIdSortedByRating(c *fiber.Ctx) error {
+	propertyId := c.Params("propertyId")
+	fmt.Println("propertyId", propertyId)
+	parsedPropertyID, err := uuid.Parse(propertyId)
+	if err != nil {
+		return utils.ResponseError(c, apperror.New(apperror.BadRequest).Describe("Invalid property ID"))
+	}
+	var ratings []models.RatingResponse
+	if err := h.service.GetRatingByPropertyIdSortedByRating(parsedPropertyID, &ratings); err != nil {
 		return utils.ResponseError(c, err)
 	}
 	return c.JSON(ratings)

--- a/internal/core/ratings/ratings.handler.go
+++ b/internal/core/ratings/ratings.handler.go
@@ -29,6 +29,18 @@ func NewHandler(service Service) Handler {
 	}
 }
 
+// @router /api/v1/ratings [post]
+// @summary Create rating
+// @description Create rating
+// @tags ratings
+// @produce json
+// @param rating body string true " rating: Rating4_5 | Rating4 | Rating3_5 | Rating3"
+// @param review body string true "review"
+// @param property_id body string true "property_id"
+// @success 200 {object} models.RatingResponse
+// @failure 400 {object} models.ErrorResponses
+// @failure 401 {object} models.ErrorResponses
+// @failure 500 {object} models.ErrorResponses
 func (h *handlerImpl) CreateRating(c *fiber.Ctx) error {
 	session, ok := c.Locals("session").(models.Sessions)
 	if !ok {
@@ -57,6 +69,16 @@ func (h *handlerImpl) CreateRating(c *fiber.Ctx) error {
 	})
 }
 
+// @router /api/v1/ratings/:propertyId [get]
+// @summary Get rating by property id
+// @description Get rating by property id
+// @tags ratings
+// @produce json
+// @param propertyId path string true "propertyId"
+// @success 200 {object} models.RatingResponse
+// @failure 400 {object} models.ErrorResponses
+// @failure 401 {object} models.ErrorResponses
+// @failure 500 {object} models.ErrorResponses
 func (h *handlerImpl) GetRatingByPropertyId(c *fiber.Ctx) error {
 	propertyId := c.Params("propertyId")
 	fmt.Println("propertyId", propertyId)
@@ -71,6 +93,15 @@ func (h *handlerImpl) GetRatingByPropertyId(c *fiber.Ctx) error {
 	return c.JSON(ratings)
 }
 
+// @router /api/v1/ratings [get]
+// @summary Get all ratings
+// @description Get all ratings
+// @tags ratings
+// @produce json
+// @success 200 {object} models.RatingResponse
+// @failure 400 {object} models.ErrorResponses
+// @failure 401 {object} models.ErrorResponses
+// @failure 500 {object} models.ErrorResponses
 func (h *handlerImpl) GetAllRatings(c *fiber.Ctx) error {
 	var ratings []models.RatingResponse
 	if err := h.service.GetAllRatings(&ratings); err != nil {
@@ -79,6 +110,16 @@ func (h *handlerImpl) GetAllRatings(c *fiber.Ctx) error {
 	return c.JSON(ratings)
 }
 
+// @router /api/v1/ratings/sorted/:propertyId [get]
+// @summary Get rating by property id sorted by rating
+// @description Get rating by property id sorted by rating
+// @tags ratings
+// @produce json
+// @param propertyId path string true "propertyId"
+// @success 200 {object} models.RatingResponse
+// @failure 400 {object} models.ErrorResponses
+// @failure 401 {object} models.ErrorResponses
+// @failure 500 {object} models.ErrorResponses
 func (h *handlerImpl) GetRatingByPropertyIdSortedByRating(c *fiber.Ctx) error {
 	propertyId := c.Params("propertyId")
 	fmt.Println("propertyId", propertyId)
@@ -93,6 +134,16 @@ func (h *handlerImpl) GetRatingByPropertyIdSortedByRating(c *fiber.Ctx) error {
 	return c.JSON(ratings)
 }
 
+// @router /api/v1/ratings/newest/:propertyId [get]
+// @summary Get rating by property id sorted by newest
+// @description Get rating by property id sorted by newest
+// @tags ratings
+// @produce json
+// @param propertyId path string true "propertyId"
+// @success 200 {object} models.RatingResponse
+// @failure 400 {object} models.ErrorResponses
+// @failure 401 {object} models.ErrorResponses
+// @failure 500 {object} models.ErrorResponses
 func (h *handlerImpl) GetRatingByPropertyIdSortedByNewest(c *fiber.Ctx) error {
 	propertyId := c.Params("propertyId")
 	fmt.Println("propertyId", propertyId)
@@ -107,6 +158,20 @@ func (h *handlerImpl) GetRatingByPropertyIdSortedByNewest(c *fiber.Ctx) error {
 	return c.JSON(ratings)
 }
 
+// apiv1.Patch("/ratings/:ratingId", mw.AuthMiddlewareWrapper(ratingsHandler.UpdateRatingStatus))
+
+// @router /api/v1/ratings/:ratingId [patch]
+// @summary Update rating status
+// @description Update rating status
+// @tags ratings
+// @produce json
+// @param ratingId path string true "ratingId"
+// @param review body string true "review"
+// @param rating body string true "rating"
+// @success 200 {object} models.MessageResponses
+// @failure 400 {object} models.ErrorResponses
+// @failure 401 {object} models.ErrorResponses
+// @failure 500 {object} models.ErrorResponses
 func (h *handlerImpl) UpdateRatingStatus(c *fiber.Ctx) error {
 	updatingRating := models.UpdateRatingStatus{}
 	err := c.BodyParser(&updatingRating)

--- a/internal/core/ratings/ratings.handler.go
+++ b/internal/core/ratings/ratings.handler.go
@@ -17,6 +17,7 @@ type Handler interface {
 	GetRatingByPropertyIdSortedByRating(c *fiber.Ctx) error
 	GetRatingByPropertyIdSortedByNewest(c *fiber.Ctx) error
 	UpdateRatingStatus(c *fiber.Ctx) error
+	DeleteRating(c *fiber.Ctx) error
 }
 
 type handlerImpl struct {
@@ -190,6 +191,28 @@ func (h *handlerImpl) UpdateRatingStatus(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{
 		"success": true,
 		"message": "Rating status updated successfully",
+	})
+
+}
+
+// @router /api/v1/ratings/:ratingId [delete]
+// @summary Delete rating
+// @description Delete rating
+// @tags ratings
+// @produce json
+// @param ratingId path string true "ratingId"
+// @success 200 {object} models.MessageResponses
+// @failure 400 {object} models.ErrorResponses
+// @failure 401 {object} models.ErrorResponses
+// @failure 500 {object} models.ErrorResponses
+func (h *handlerImpl) DeleteRating(c *fiber.Ctx) error {
+	ratingId := c.Params("ratingId")
+	err := h.service.DeleteRating(ratingId)
+	if err != nil {
+		return utils.ResponseError(c, err)
+	}
+	return c.JSON(fiber.Map{
+		"message": "Rating deleted",
 	})
 
 }

--- a/internal/core/ratings/ratings.handler.go
+++ b/internal/core/ratings/ratings.handler.go
@@ -1,0 +1,46 @@
+package ratings
+
+import (
+	"github.com/brain-flowing-company/pprp-backend/apperror"
+	"github.com/brain-flowing-company/pprp-backend/internal/models"
+	"github.com/brain-flowing-company/pprp-backend/internal/utils"
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+)
+
+type Handler interface {
+	CreateRating(c *fiber.Ctx) error
+}
+
+type handlerImpl struct {
+	service Service
+}
+
+func NewHandler(service Service) Handler {
+	return &handlerImpl{
+		service,
+	}
+}
+
+func (h *handlerImpl) CreateRating(c *fiber.Ctx) error {
+	reviews := models.Reviews{
+		ReviewId: uuid.New(),
+	}
+	if err := c.BodyParser(&reviews); err != nil {
+		return utils.ResponseError(c, apperror.New(apperror.BadRequest).Describe("Failed to parse body"))
+	}
+	if !utils.IsValidRating(string(reviews.Rating)) {
+		return utils.ResponseError(c, apperror.New(apperror.BadRequest).Describe("Invalid rating"))
+	}
+	if err := h.service.CreateRating(&reviews); err != nil {
+		return utils.ResponseError(c, err)
+	}
+	return c.JSON(fiber.Map{
+		"success":         true,
+		"message":         "Rating created successfully",
+		"rating":          reviews.Rating,
+		"review":          reviews.Review,
+		"property_id":     reviews.PropertyId,
+		"dweller_user_id": reviews.DwellerUserId,
+	})
+}

--- a/internal/core/ratings/ratings.handler.go
+++ b/internal/core/ratings/ratings.handler.go
@@ -13,6 +13,7 @@ import (
 type Handler interface {
 	CreateRating(c *fiber.Ctx) error
 	GetRatingByPropertyId(c *fiber.Ctx) error
+	GetAllRatings(c *fiber.Ctx) error
 }
 
 type handlerImpl struct {
@@ -62,6 +63,14 @@ func (h *handlerImpl) GetRatingByPropertyId(c *fiber.Ctx) error {
 	}
 	var ratings []models.RatingResponse
 	if err := h.service.GetRatingByPropertyId(parsedPropertyID, &ratings); err != nil {
+		return utils.ResponseError(c, err)
+	}
+	return c.JSON(ratings)
+}
+
+func (h *handlerImpl) GetAllRatings(c *fiber.Ctx) error {
+	var ratings []models.RatingResponse
+	if err := h.service.GetAllRatings(&ratings); err != nil {
 		return utils.ResponseError(c, err)
 	}
 	return c.JSON(ratings)

--- a/internal/core/ratings/ratings.handler.go
+++ b/internal/core/ratings/ratings.handler.go
@@ -35,7 +35,7 @@ func NewHandler(service Service) Handler {
 // @description Create rating
 // @tags ratings
 // @produce json
-// @param rating body string true " rating: Rating4_5 | Rating4 | Rating3_5 | Rating3"
+// @param rating body int true "rating"
 // @param review body string true "review"
 // @param property_id body string true "property_id"
 // @success 200 {object} models.RatingResponse
@@ -54,7 +54,7 @@ func (h *handlerImpl) CreateRating(c *fiber.Ctx) error {
 	if err := c.BodyParser(&reviews); err != nil {
 		return utils.ResponseError(c, apperror.New(apperror.BadRequest).Describe("Failed to parse body"))
 	}
-	if !utils.IsValidRating(string(reviews.Rating)) {
+	if !utils.IsValidRating(reviews.Rating) {
 		return utils.ResponseError(c, apperror.New(apperror.BadRequest).Describe("Invalid rating"))
 	}
 	if err := h.service.CreateRating(&reviews); err != nil {
@@ -168,7 +168,7 @@ func (h *handlerImpl) GetRatingByPropertyIdSortedByNewest(c *fiber.Ctx) error {
 // @produce json
 // @param ratingId path string true "ratingId"
 // @param review body string true "review"
-// @param rating body string true "rating"
+// @param rating body int true "rating"
 // @success 200 {object} models.MessageResponses
 // @failure 400 {object} models.ErrorResponses
 // @failure 401 {object} models.ErrorResponses
@@ -178,6 +178,9 @@ func (h *handlerImpl) UpdateRatingStatus(c *fiber.Ctx) error {
 	err := c.BodyParser(&updatingRating)
 	if err != nil {
 		return utils.ResponseError(c, apperror.New(apperror.BadRequest).Describe("Failed to parse body"))
+	}
+	if !utils.IsValidRating(updatingRating.Rating) {
+		return utils.ResponseError(c, apperror.New(apperror.BadRequest).Describe("Invalid rating"))
 	}
 	ratingId := c.Params("ratingId")
 	ratingIdParsed, err := uuid.Parse(ratingId)

--- a/internal/core/ratings/ratings.handler.go
+++ b/internal/core/ratings/ratings.handler.go
@@ -15,6 +15,7 @@ type Handler interface {
 	GetRatingByPropertyId(c *fiber.Ctx) error
 	GetAllRatings(c *fiber.Ctx) error
 	GetRatingByPropertyIdSortedByRating(c *fiber.Ctx) error
+	GetRatingByPropertyIdSortedByNewest(c *fiber.Ctx) error
 }
 
 type handlerImpl struct {
@@ -86,6 +87,20 @@ func (h *handlerImpl) GetRatingByPropertyIdSortedByRating(c *fiber.Ctx) error {
 	}
 	var ratings []models.RatingResponse
 	if err := h.service.GetRatingByPropertyIdSortedByRating(parsedPropertyID, &ratings); err != nil {
+		return utils.ResponseError(c, err)
+	}
+	return c.JSON(ratings)
+}
+
+func (h *handlerImpl) GetRatingByPropertyIdSortedByNewest(c *fiber.Ctx) error {
+	propertyId := c.Params("propertyId")
+	fmt.Println("propertyId", propertyId)
+	parsedPropertyID, err := uuid.Parse(propertyId)
+	if err != nil {
+		return utils.ResponseError(c, apperror.New(apperror.BadRequest).Describe("Invalid property ID"))
+	}
+	var ratings []models.RatingResponse
+	if err := h.service.GetRatingByPropertyIdSortedByNewest(parsedPropertyID, &ratings); err != nil {
 		return utils.ResponseError(c, err)
 	}
 	return c.JSON(ratings)

--- a/internal/core/ratings/ratings.repository.go
+++ b/internal/core/ratings/ratings.repository.go
@@ -14,6 +14,7 @@ type Repository interface {
 	GetRatingByPropertyId(uuid.UUID, *[]models.RatingResponse) error
 	GetAllRatings(*[]models.RatingResponse) error
 	GetRatingByPropertyIdSortedByRating(propertyId uuid.UUID, ratings *[]models.RatingResponse) error
+	GetRatingByPropertyIdSortedByNewest(propertyId uuid.UUID, ratings *[]models.RatingResponse) error
 }
 
 type repositoryImpl struct {
@@ -104,6 +105,29 @@ func (r *repositoryImpl) GetRatingByPropertyIdSortedByRating(propertyId uuid.UUI
 		Joins("LEFT JOIN _users ON review.dweller_user_id = _users.user_id").
 		Where("property_id = ?", propertyId).
 		Order("rating desc").
+		Scan(&ratings).Error
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *repositoryImpl) GetRatingByPropertyIdSortedByNewest(propertyId uuid.UUID, ratings *[]models.RatingResponse) error {
+	fmt.Println("propertyId", propertyId)
+	var propertyCount int64
+	if err := r.db.Model(&models.Properties{}).Where("property_id = ?", propertyId).Count(&propertyCount).Error; err != nil {
+		return err
+	}
+	if propertyCount == 0 {
+		return apperror.
+			New(apperror.PropertyNotFound).
+			Describe("Property not found")
+	}
+	err := r.db.Table("review").
+		Select("review.*, _users.first_name ,_users.last_name").
+		Joins("LEFT JOIN _users ON review.dweller_user_id = _users.user_id").
+		Where("property_id = ?", propertyId).
+		Order("created_at desc").
 		Scan(&ratings).Error
 	if err != nil {
 		return err

--- a/internal/core/ratings/ratings.repository.go
+++ b/internal/core/ratings/ratings.repository.go
@@ -1,0 +1,49 @@
+package ratings
+
+import (
+	"github.com/brain-flowing-company/pprp-backend/apperror"
+	"github.com/brain-flowing-company/pprp-backend/internal/models"
+	"gorm.io/gorm"
+)
+
+type Repository interface {
+	CreateRating(*models.Reviews) error
+}
+
+type repositoryImpl struct {
+	db *gorm.DB
+}
+
+func NewRepository(db *gorm.DB) Repository {
+	return &repositoryImpl{
+		db,
+	}
+}
+
+func (r *repositoryImpl) CreateRating(reviews *models.Reviews) error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		var userCount int64
+		if err := tx.Model(&models.Users{}).Where("user_id = ?", reviews.DwellerUserId).Count(&userCount).Error; err != nil {
+			return err
+		}
+		if userCount == 0 {
+			return apperror.
+				New(apperror.UserNotFound).
+				Describe("FK constraint in user table")
+		}
+		var propertyCount int64
+		if err := tx.Model(&models.Properties{}).Where("property_id = ?", reviews.PropertyId).Count(&propertyCount).Error; err != nil {
+			return err
+		}
+		if propertyCount == 0 {
+			return apperror.
+				New(apperror.PropertyNotFound).
+				Describe("FK constraint in property table")
+		}
+		reviewQuery := `INSERT INTO review (review_id, property_id, dweller_user_id, rating, review) VALUES (?,?,?,?,?)`
+		if err := tx.Exec(reviewQuery, reviews.ReviewId, reviews.PropertyId, reviews.DwellerUserId, reviews.Rating, reviews.Review).Error; err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/internal/core/ratings/ratings.repository.go
+++ b/internal/core/ratings/ratings.repository.go
@@ -137,9 +137,6 @@ func (r *repositoryImpl) GetRatingByPropertyIdSortedByNewest(propertyId uuid.UUI
 }
 
 func (r *repositoryImpl) UpdateRatingStatus(updateStatus *models.UpdateRatingStatus, ratingId uuid.UUID) error {
-	fmt.Println("ratingId", ratingId)
-	fmt.Println("updateStatus", updateStatus.Rating)
-	fmt.Println("updateStatus", updateStatus.Review)
 	if err := r.db.Model(&models.Reviews{}).First(&models.Reviews{}, "review_id = ?", ratingId).Error; err != nil {
 		return err
 	}

--- a/internal/core/ratings/ratings.repository.go
+++ b/internal/core/ratings/ratings.repository.go
@@ -12,6 +12,7 @@ import (
 type Repository interface {
 	CreateRating(*models.Reviews) error
 	GetRatingByPropertyId(uuid.UUID, *[]models.RatingResponse) error
+	GetAllRatings(*[]models.RatingResponse) error
 }
 
 type repositoryImpl struct {
@@ -73,4 +74,15 @@ func (r *repositoryImpl) GetRatingByPropertyId(propertyId uuid.UUID, ratings *[]
 	}
 	return nil
 
+}
+
+func (r *repositoryImpl) GetAllRatings(ratings *[]models.RatingResponse) error {
+	err := r.db.Table("review").
+		Select("review.*, _users.first_name ,_users.last_name").
+		Joins("LEFT JOIN _users ON review.dweller_user_id = _users.user_id").
+		Scan(&ratings).Error
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/core/ratings/ratings.repository.go
+++ b/internal/core/ratings/ratings.repository.go
@@ -16,6 +16,7 @@ type Repository interface {
 	GetRatingByPropertyIdSortedByRating(propertyId uuid.UUID, ratings *[]models.RatingResponse) error
 	GetRatingByPropertyIdSortedByNewest(propertyId uuid.UUID, ratings *[]models.RatingResponse) error
 	UpdateRatingStatus(updateStatus *models.UpdateRatingStatus, ratingId uuid.UUID) error
+	DeleteRating(ratingId string) error
 }
 
 type repositoryImpl struct {
@@ -141,4 +142,12 @@ func (r *repositoryImpl) UpdateRatingStatus(updateStatus *models.UpdateRatingSta
 		return err
 	}
 	return r.db.Model(&models.Reviews{}).Where("review_id = ?", ratingId).Updates(updateStatus).Error
+}
+
+func (r *repositoryImpl) DeleteRating(ratingId string) error {
+	if err := r.db.Model(&models.Reviews{}).First(&models.Reviews{}, "review_id = ?", ratingId).Error; err != nil {
+		return err
+	}
+
+	return r.db.Where("review_id = ?", ratingId).Delete(&models.Reviews{}).Error
 }

--- a/internal/core/ratings/ratings.service.go
+++ b/internal/core/ratings/ratings.service.go
@@ -10,6 +10,7 @@ import (
 type Service interface {
 	CreateRating(*models.Reviews) error
 	GetRatingByPropertyId(uuid.UUID, *[]models.RatingResponse) error
+	GetAllRatings(*[]models.RatingResponse) error
 }
 
 type serviceImpl struct {
@@ -39,6 +40,15 @@ func (s *serviceImpl) GetRatingByPropertyId(propertyId uuid.UUID, ratings *[]mod
 	err := s.repo.GetRatingByPropertyId(propertyId, ratings)
 	if err != nil {
 		s.logger.Error("Failed to get rating by property id", zap.Error(err))
+		return err
+	}
+	return nil
+}
+
+func (s *serviceImpl) GetAllRatings(ratings *[]models.RatingResponse) error {
+	err := s.repo.GetAllRatings(ratings)
+	if err != nil {
+		s.logger.Error("Failed to get all ratings", zap.Error(err))
 		return err
 	}
 	return nil

--- a/internal/core/ratings/ratings.service.go
+++ b/internal/core/ratings/ratings.service.go
@@ -1,0 +1,34 @@
+package ratings
+
+import (
+	"github.com/brain-flowing-company/pprp-backend/config"
+	"github.com/brain-flowing-company/pprp-backend/internal/models"
+	"go.uber.org/zap"
+)
+
+type Service interface {
+	CreateRating(*models.Reviews) error
+}
+
+type serviceImpl struct {
+	repo   Repository
+	logger *zap.Logger
+	cfg    *config.Config
+}
+
+func NewService(repo Repository, logger *zap.Logger, cfg *config.Config) Service {
+	return &serviceImpl{
+		repo,
+		logger,
+		cfg,
+	}
+}
+
+func (s *serviceImpl) CreateRating(reviews *models.Reviews) error {
+	err := s.repo.CreateRating(reviews)
+	if err != nil {
+		s.logger.Error("Failed to create rating", zap.Error(err))
+		return err
+	}
+	return nil
+}

--- a/internal/core/ratings/ratings.service.go
+++ b/internal/core/ratings/ratings.service.go
@@ -3,11 +3,13 @@ package ratings
 import (
 	"github.com/brain-flowing-company/pprp-backend/config"
 	"github.com/brain-flowing-company/pprp-backend/internal/models"
+	"github.com/google/uuid"
 	"go.uber.org/zap"
 )
 
 type Service interface {
 	CreateRating(*models.Reviews) error
+	GetRatingByPropertyId(uuid.UUID, *[]models.RatingResponse) error
 }
 
 type serviceImpl struct {
@@ -28,6 +30,15 @@ func (s *serviceImpl) CreateRating(reviews *models.Reviews) error {
 	err := s.repo.CreateRating(reviews)
 	if err != nil {
 		s.logger.Error("Failed to create rating", zap.Error(err))
+		return err
+	}
+	return nil
+}
+
+func (s *serviceImpl) GetRatingByPropertyId(propertyId uuid.UUID, ratings *[]models.RatingResponse) error {
+	err := s.repo.GetRatingByPropertyId(propertyId, ratings)
+	if err != nil {
+		s.logger.Error("Failed to get rating by property id", zap.Error(err))
 		return err
 	}
 	return nil

--- a/internal/core/ratings/ratings.service.go
+++ b/internal/core/ratings/ratings.service.go
@@ -12,6 +12,7 @@ type Service interface {
 	GetRatingByPropertyId(uuid.UUID, *[]models.RatingResponse) error
 	GetAllRatings(*[]models.RatingResponse) error
 	GetRatingByPropertyIdSortedByRating(propertyId uuid.UUID, ratings *[]models.RatingResponse) error
+	GetRatingByPropertyIdSortedByNewest(propertyId uuid.UUID, ratings *[]models.RatingResponse) error
 }
 
 type serviceImpl struct {
@@ -59,6 +60,15 @@ func (s *serviceImpl) GetRatingByPropertyIdSortedByRating(propertyId uuid.UUID, 
 	err := s.repo.GetRatingByPropertyIdSortedByRating(propertyId, ratings)
 	if err != nil {
 		s.logger.Error("Failed to get rating by property id sorted by rating", zap.Error(err))
+		return err
+	}
+	return nil
+}
+
+func (s *serviceImpl) GetRatingByPropertyIdSortedByNewest(propertyId uuid.UUID, ratings *[]models.RatingResponse) error {
+	err := s.repo.GetRatingByPropertyIdSortedByNewest(propertyId, ratings)
+	if err != nil {
+		s.logger.Error("Failed to get rating by property id sorted by newest", zap.Error(err))
 		return err
 	}
 	return nil

--- a/internal/core/ratings/ratings.service.go
+++ b/internal/core/ratings/ratings.service.go
@@ -11,6 +11,7 @@ type Service interface {
 	CreateRating(*models.Reviews) error
 	GetRatingByPropertyId(uuid.UUID, *[]models.RatingResponse) error
 	GetAllRatings(*[]models.RatingResponse) error
+	GetRatingByPropertyIdSortedByRating(propertyId uuid.UUID, ratings *[]models.RatingResponse) error
 }
 
 type serviceImpl struct {
@@ -49,6 +50,15 @@ func (s *serviceImpl) GetAllRatings(ratings *[]models.RatingResponse) error {
 	err := s.repo.GetAllRatings(ratings)
 	if err != nil {
 		s.logger.Error("Failed to get all ratings", zap.Error(err))
+		return err
+	}
+	return nil
+}
+
+func (s *serviceImpl) GetRatingByPropertyIdSortedByRating(propertyId uuid.UUID, ratings *[]models.RatingResponse) error {
+	err := s.repo.GetRatingByPropertyIdSortedByRating(propertyId, ratings)
+	if err != nil {
+		s.logger.Error("Failed to get rating by property id sorted by rating", zap.Error(err))
 		return err
 	}
 	return nil

--- a/internal/enums/review_rating.enums.go
+++ b/internal/enums/review_rating.enums.go
@@ -1,0 +1,17 @@
+package enums
+
+type Rating string
+
+const (
+	Rating0   Rating = "Rating0"
+	Rating0_5 Rating = "Rating0_5"
+	Rating1   Rating = "Rating1"
+	Rating1_5 Rating = "Rating1_5"
+	Rating2   Rating = "Rating2"
+	Rating2_5 Rating = "Rating2_5"
+	Rating3   Rating = "Rating3"
+	Rating3_5 Rating = "Rating3_5"
+	Rating4   Rating = "Rating4"
+	Rating4_5 Rating = "Rating4_5"
+	Rating5   Rating = "Rating5"
+)

--- a/internal/models/payments.models.go
+++ b/internal/models/payments.models.go
@@ -43,19 +43,3 @@ type HistoryResponse struct {
 	CancelledMessage string                `json:"cancelled_message"`
 	CommonModels
 }
-
-// type Agreements struct {
-// 	AgreementId   uuid.UUID `json:"agreement_id" gorm:"type:uuid;default:uuid_generate_v4();primaryKey"`
-// 	AgreementType enums.AgreementTypes `json:"agreement_type" example:"SELLING"`
-// 	PropertyId    uuid.UUID `json:"property_id" example:"00000000-0000-0000-0000-000000000000"`
-// 	OwnerUserId   uuid.UUID `json:"owner_user_id" example:"00000000-0000-0000-0000-000000000000"`
-// 	DwellerUserId uuid.UUID `json:"dweller_user_id" example:"00000000-0000-0000-0000-000000000000"`
-// 	AgreementDate time.Time `json:"agreement_date" example:"2021-01-01T00:00:00Z"`
-// 	Status enums.AgreementStatus `json:"status" example:"AWAITING_DEPOSIT"`
-// 	DepositAmount float64 `json:"deposit_amount" example:"1000000"`
-// 	PaymentPerMonth float64 `json:"payment_per_month" example:"1000000"`
-// 	PaymentDuration int `json:"payment_duration" example:"12"`
-// 	TotalPayment float64 `json:"total_payment" example:"12000000"`
-// 	CancelledMessage string `json:"cancelled_message" example:"This is cancelled message."`
-// 	CommonModels
-// }

--- a/internal/models/ratings.models.go
+++ b/internal/models/ratings.models.go
@@ -1,31 +1,30 @@
 package models
 
 import (
-	"github.com/brain-flowing-company/pprp-backend/internal/enums"
 	"github.com/google/uuid"
 )
 
 type Reviews struct {
-	ReviewId      uuid.UUID    `json:"review_id" gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
-	PropertyId    uuid.UUID    `json:"property_id" gorm:"type:uuid;not null"`
-	DwellerUserId uuid.UUID    `json:"dweller_user_id" gorm:"type:uuid;not null"`
-	Rating        enums.Rating `json:"rating" gorm:"type:rating;not null"`
-	Review        string       `json:"review" gorm:"type:text;default:null"`
+	ReviewId      uuid.UUID `json:"review_id" gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+	PropertyId    uuid.UUID `json:"property_id" gorm:"type:uuid;not null"`
+	DwellerUserId uuid.UUID `json:"dweller_user_id" gorm:"type:uuid;not null"`
+	Rating        int8      `json:"rating" gorm:"type:rating;not null"`
+	Review        string    `json:"review" gorm:"type:text;default:null"`
 	CommonModels
 }
 
 type RatingResponse struct {
-	ReviewId      uuid.UUID    `json:"review_id"`
-	PropertyId    uuid.UUID    `json:"property_id"`
-	DwellerUserId uuid.UUID    `json:"dweller_user_id"`
-	FirstName     string       `json:"first_name"`
-	LastName      string       `json:"last_name"`
-	Rating        enums.Rating `json:"rating"`
-	Review        string       `json:"review"`
+	ReviewId      uuid.UUID `json:"review_id"`
+	PropertyId    uuid.UUID `json:"property_id"`
+	DwellerUserId uuid.UUID `json:"dweller_user_id"`
+	FirstName     string    `json:"first_name"`
+	LastName      string    `json:"last_name"`
+	Rating        int8      `json:"rating"`
+	Review        string    `json:"review"`
 	CommonModels
 }
 
 type UpdateRatingStatus struct {
-	Rating enums.Rating `json:"rating"`
-	Review string       `json:"review"`
+	Rating int8   `json:"rating"`
+	Review string `json:"review"`
 }

--- a/internal/models/ratings.models.go
+++ b/internal/models/ratings.models.go
@@ -5,17 +5,6 @@ import (
 	"github.com/google/uuid"
 )
 
-// CREATE TABLE review(
-//     review_id UUID PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
-//     property_id UUID REFERENCES properties(property_id) NOT NULL,
-//     dweller_user_id UUID REFERENCES users(user_id) NOT NULL,
-//     rating Rating NOT NULL,
-//     review TEXT DEFAULT NULL,
-//     created_at TIMESTAMP(0) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-//     updated_at TIMESTAMP(0) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-//     deleted_at TIMESTAMP(0) WITH TIME ZONE DEFAULT NULL
-// );
-
 type Reviews struct {
 	ReviewId      uuid.UUID    `json:"review_id" gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
 	PropertyId    uuid.UUID    `json:"property_id" gorm:"type:uuid;not null"`
@@ -36,15 +25,7 @@ type RatingResponse struct {
 	CommonModels
 }
 
-// type Users struct {
-// 	UserId          uuid.UUID             `json:"user_id"                      gorm:"default:uuid_generate_v4()"`
-// 	RegisteredType  enums.RegisteredTypes `json:"registered_type"              example:"EMAIL"`
-// 	Email           string                `json:"email"                        form:"email"                        gorm:"unique" example:"email@email.com"`
-// 	Password        string                `json:"password"                     form:"password"                     gorm:"default:null" example:"password1234"`
-// 	FirstName       string                `json:"first_name"                   form:"first_name"                   example:"John"`
-// 	LastName        string                `json:"last_name"                    form:"last_name"                    example:"Doe"`
-// 	PhoneNumber     string                `json:"phone_number"                 form:"phone_number"                 gorm:"unique" example:"0812345678"`
-// 	ProfileImageUrl string                `json:"profile_image_url"            form:"profile_image_url"            gorm:"default:null" example:"https://image_url.com/abcd"`
-// 	IsVerified      bool                  `json:"is_verified"                  gorm:"default:null" example:"false"`
-// 	CommonModels
-// }
+type UpdateRatingStatus struct {
+	Rating enums.Rating `json:"rating"`
+	Review string       `json:"review"`
+}

--- a/internal/models/ratings.models.go
+++ b/internal/models/ratings.models.go
@@ -1,0 +1,26 @@
+package models
+
+import (
+	"github.com/brain-flowing-company/pprp-backend/internal/enums"
+	"github.com/google/uuid"
+)
+
+// CREATE TABLE review(
+//     review_id UUID PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+//     property_id UUID REFERENCES properties(property_id) NOT NULL,
+//     dweller_user_id UUID REFERENCES users(user_id) NOT NULL,
+//     rating Rating NOT NULL,
+//     review TEXT DEFAULT NULL,
+//     created_at TIMESTAMP(0) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+//     updated_at TIMESTAMP(0) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+//     deleted_at TIMESTAMP(0) WITH TIME ZONE DEFAULT NULL
+// );
+
+type Reviews struct {
+	ReviewId      uuid.UUID    `json:"review_id" gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+	PropertyId    uuid.UUID    `json:"property_id" gorm:"type:uuid;not null"`
+	DwellerUserId uuid.UUID    `json:"dweller_user_id" gorm:"type:uuid;not null"`
+	Rating        enums.Rating `json:"rating" gorm:"type:rating;not null"`
+	Review        string       `json:"review" gorm:"type:text;default:null"`
+	CommonModels
+}

--- a/internal/models/ratings.models.go
+++ b/internal/models/ratings.models.go
@@ -24,3 +24,27 @@ type Reviews struct {
 	Review        string       `json:"review" gorm:"type:text;default:null"`
 	CommonModels
 }
+
+type RatingResponse struct {
+	ReviewId      uuid.UUID    `json:"review_id"`
+	PropertyId    uuid.UUID    `json:"property_id"`
+	DwellerUserId uuid.UUID    `json:"dweller_user_id"`
+	FirstName     string       `json:"first_name"`
+	LastName      string       `json:"last_name"`
+	Rating        enums.Rating `json:"rating"`
+	Review        string       `json:"review"`
+	CommonModels
+}
+
+// type Users struct {
+// 	UserId          uuid.UUID             `json:"user_id"                      gorm:"default:uuid_generate_v4()"`
+// 	RegisteredType  enums.RegisteredTypes `json:"registered_type"              example:"EMAIL"`
+// 	Email           string                `json:"email"                        form:"email"                        gorm:"unique" example:"email@email.com"`
+// 	Password        string                `json:"password"                     form:"password"                     gorm:"default:null" example:"password1234"`
+// 	FirstName       string                `json:"first_name"                   form:"first_name"                   example:"John"`
+// 	LastName        string                `json:"last_name"                    form:"last_name"                    example:"Doe"`
+// 	PhoneNumber     string                `json:"phone_number"                 form:"phone_number"                 gorm:"unique" example:"0812345678"`
+// 	ProfileImageUrl string                `json:"profile_image_url"            form:"profile_image_url"            gorm:"default:null" example:"https://image_url.com/abcd"`
+// 	IsVerified      bool                  `json:"is_verified"                  gorm:"default:null" example:"false"`
+// 	CommonModels
+// }

--- a/internal/utils/validator.utils.go
+++ b/internal/utils/validator.utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"net/mail"
 
+	"github.com/brain-flowing-company/pprp-backend/internal/enums"
 	"github.com/google/uuid"
 )
 
@@ -29,4 +30,13 @@ func IsValidPassword(password string) bool {
 
 func IsValidEmailVerificationCode(code string) bool {
 	return len(code) == 10 && code[:4] == "SCK-"
+}
+
+func IsValidRating(rating string) bool {
+	switch rating {
+	case string(enums.Rating0), string(enums.Rating0_5), string(enums.Rating1), string(enums.Rating1_5), string(enums.Rating2), string(enums.Rating2_5), string(enums.Rating3), string(enums.Rating3_5), string(enums.Rating4), string(enums.Rating4_5), string(enums.Rating5):
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/utils/validator.utils.go
+++ b/internal/utils/validator.utils.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"net/mail"
 
-	"github.com/brain-flowing-company/pprp-backend/internal/enums"
 	"github.com/google/uuid"
 )
 
@@ -32,11 +31,9 @@ func IsValidEmailVerificationCode(code string) bool {
 	return len(code) == 10 && code[:4] == "SCK-"
 }
 
-func IsValidRating(rating string) bool {
-	switch rating {
-	case string(enums.Rating0), string(enums.Rating0_5), string(enums.Rating1), string(enums.Rating1_5), string(enums.Rating2), string(enums.Rating2_5), string(enums.Rating3), string(enums.Rating3_5), string(enums.Rating4), string(enums.Rating4_5), string(enums.Rating5):
-		return true
-	default:
+func IsValidRating(rating int8) bool {
+	if rating < 0 || rating > 5 {
 		return false
 	}
+	return true
 }

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -17,6 +17,9 @@ CREATE TYPE furnishing AS ENUM('UNFURNISHED', 'PARTIALLY_FURNISHED', 'FULLY_FURN
 CREATE TYPE floor_size_units AS ENUM('SQM', 'SQFT');
 
 CREATE TYPE payment_methods AS ENUM('CREDIT_CARD', 'PROMPTPAY');
+
+CREATE TYPE Rating AS ENUM('Rating0' , 'Rating0_5' , 'Rating1' , 'Rating1_5' , 'Rating2' , 'Rating2_5' , 'Rating3' , 'Rating3_5' , 'Rating4' , 'Rating4_5' , 'Rating5');
+
  
 CREATE TABLE email_verification_codes
 (
@@ -209,6 +212,18 @@ CREATE TABLE payments(
     updated_at TIMESTAMP(0) WITH TIME ZONE                DEFAULT CURRENT_TIMESTAMP, 
     deleted_at TIMESTAMP(0) WITH TIME ZONE                DEFAULT NULL
 );
+
+CREATE TABLE review(
+    review_id UUID PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+    property_id UUID REFERENCES properties(property_id) NOT NULL, 
+    dweller_user_id UUID REFERENCES users(user_id) NOT NULL, 
+    rating Rating NOT NULL, 
+    review TEXT NOT NULL,
+    created_at TIMESTAMP(0) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP(0) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP(0) WITH TIME ZONE DEFAULT NULL
+);
+
 
 -------------------- RULES --------------------
 

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -17,9 +17,6 @@ CREATE TYPE furnishing AS ENUM('UNFURNISHED', 'PARTIALLY_FURNISHED', 'FULLY_FURN
 CREATE TYPE floor_size_units AS ENUM('SQM', 'SQFT');
 
 CREATE TYPE payment_methods AS ENUM('CREDIT_CARD', 'PROMPTPAY');
-
-CREATE TYPE Rating AS ENUM('Rating0' , 'Rating0_5' , 'Rating1' , 'Rating1_5' , 'Rating2' , 'Rating2_5' , 'Rating3' , 'Rating3_5' , 'Rating4' , 'Rating4_5' , 'Rating5');
-
  
 CREATE TABLE email_verification_codes
 (
@@ -217,7 +214,7 @@ CREATE TABLE reviews(
     review_id UUID PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
     property_id UUID REFERENCES properties(property_id) NOT NULL, 
     dweller_user_id UUID REFERENCES users(user_id) NOT NULL, 
-    rating Rating NOT NULL, 
+    rating INTEGER NOT NULL, 
     review TEXT NOT NULL,
     created_at TIMESTAMP(0) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP(0) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -213,7 +213,7 @@ CREATE TABLE payments(
     deleted_at TIMESTAMP(0) WITH TIME ZONE                DEFAULT NULL
 );
 
-CREATE TABLE review(
+CREATE TABLE reviews(
     review_id UUID PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
     property_id UUID REFERENCES properties(property_id) NOT NULL, 
     dweller_user_id UUID REFERENCES users(user_id) NOT NULL, 


### PR DESCRIPTION

### Description
This pull request introduces endpoints for managing ratings in the API. The following endpoints have been added:

- `POST /ratings`: Creates a new rating.
- `GET /ratings/:propertyId`: Retrieves ratings for a specific property.
- `GET /ratings`: Retrieves all ratings.
- `GET /ratings/sorted/:propertyId`: Retrieves ratings for a specific property sorted by rating.
- `GET /ratings/newest/:propertyId`: Retrieves ratings for a specific property sorted by newest.
- `PATCH /ratings/:ratingId`: Updates the status of a specific rating.
- `DELETE /ratings/:ratingId`: Deletes a specific rating.

Each endpoint is wrapped with authentication middleware to ensure secure access.

### Changes Made
- Added endpoint handlers for creating, retrieving, updating, and deleting ratings.
